### PR TITLE
feat: v2.0 - 12개 항목 체크리스트 및 Phase 시스템 구현

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,31 +1,32 @@
 // 파일 경로: app/layout.tsx
-// 설명: Next.js App Router의 루트 레이아웃 (React 19 호환)
+// 설명: Next.js 15 메타데이터 API 업데이트 적용
 
-import type { Metadata,Viewport } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import theme from './theme';
+
 /**
- * 메타데이터 설정
+ * 메타데이터 (viewport 제외)
  */
 export const metadata: Metadata = {
   title: '12주 건강관리 체크리스트',
   description: '12주간의 운동습관과 생활지표를 기록하고 관리하는 앱',
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 1,
-  },
 };
 
+/**
+ * ⭐ Viewport를 별도로 export (Next.js 15+ 필수)
+ */
 export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
   themeColor: 'black',
-}
- 
+};
+
 /**
  * RootLayout 컴포넌트
- * - Server Component로 유지 (no 'use client')
  */
 export default function RootLayout({
   children,

--- a/app/program/page.tsx
+++ b/app/program/page.tsx
@@ -1,0 +1,249 @@
+// 파일 경로: app/program/page.tsx
+// 설명: 주차별 운동/식단 프로그램 가이드
+
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Container,
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Paper,
+  Tabs,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  CircularProgress,
+} from '@mui/material';
+import { ArrowBack, FitnessCenter, Restaurant } from '@mui/icons-material';
+import { getCurrentUser } from '@/lib/localStorage';
+import { getWeekNumber, getTodayString } from '@/lib/dateUtils';
+import { getWeeklyProgram, PHASE_INFO, PHASE_COLORS, getPhaseFromWeek } from '@/lib/programData';
+import type { User } from '@/types';
+
+/**
+ * ProgramPage
+ * 
+ * 주차별 프로그램 상세 정보:
+ * - 운동 스케줄
+ * - 식단 가이드
+ * - 주간 목표
+ */
+export default function ProgramPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [selectedWeek, setSelectedWeek] = useState(1);
+  const [tabValue, setTabValue] = useState(0);
+
+  useEffect(() => {
+    const currentUser = getCurrentUser();
+    if (!currentUser) {
+      router.push('/login');
+    } else {
+      setUser(currentUser);
+      const currentWeek = getWeekNumber(currentUser.startDate, getTodayString()) || 1;
+      setSelectedWeek(currentWeek);
+      setLoading(false);
+    }
+  }, [router]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!user) return null;
+
+  const program = getWeeklyProgram(selectedWeek);
+  const phase = getPhaseFromWeek(selectedWeek);
+  const phaseInfo = PHASE_INFO[phase];
+
+  return (
+    <>
+      {/* 상단 앱바 */}
+      <AppBar position="sticky" elevation={2}>
+        <Toolbar>
+          <IconButton edge="start" color="inherit" onClick={() => router.push('/')}>
+            <ArrowBack />
+          </IconButton>
+          <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 'bold', ml: 2 }}>
+            12주 프로그램 가이드
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        {/* Phase 정보 */}
+        <Paper
+          elevation={3}
+          sx={{
+            p: 3,
+            mb: 3,
+            borderRadius: 2,
+            background: `linear-gradient(135deg, ${PHASE_COLORS[phase]} 0%, ${PHASE_COLORS[phase]}CC 100%)`,
+            color: 'white',
+          }}
+        >
+          <Typography variant="h5" fontWeight="bold" gutterBottom>
+            {phaseInfo.title}
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            {phaseInfo.description}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {phaseInfo.focusAreas.map((area) => (
+              <Chip
+                key={area}
+                label={area}
+                size="small"
+                sx={{ bgcolor: 'rgba(255, 255, 255, 0.3)', color: 'white' }}
+              />
+            ))}
+          </Box>
+        </Paper>
+
+        {/* 주차 선택 */}
+        <Paper elevation={2} sx={{ mb: 3 }}>
+          <Tabs
+            value={selectedWeek - 1}
+            onChange={(_, value) => setSelectedWeek(value + 1)}
+            variant="scrollable"
+            scrollButtons="auto"
+          >
+            {Array.from({ length: 12 }, (_, i) => i + 1).map((week) => {
+              const weekPhase = getPhaseFromWeek(week);
+              return (
+                <Tab
+                  key={week}
+                  label={`${week}주차`}
+                  sx={{
+                    fontWeight: week === selectedWeek ? 'bold' : 'normal',
+                    color: PHASE_COLORS[weekPhase],
+                  }}
+                />
+              );
+            })}
+          </Tabs>
+        </Paper>
+
+        {/* 운동 / 식단 탭 */}
+        <Paper elevation={2} sx={{ mb: 3 }}>
+          <Tabs value={tabValue} onChange={(_, value) => setTabValue(value)} centered>
+            <Tab icon={<FitnessCenter />} label="운동 스케줄" />
+            <Tab icon={<Restaurant />} label="식단 가이드" />
+          </Tabs>
+        </Paper>
+
+        {/* 운동 스케줄 탭 */}
+        {tabValue === 0 && (
+          <Paper elevation={2} sx={{ p: 3 }}>
+            <Typography variant="h6" fontWeight="bold" gutterBottom>
+              {selectedWeek}주차 운동 프로그램
+            </Typography>
+            <TableContainer>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell><strong>요일</strong></TableCell>
+                    <TableCell><strong>운동</strong></TableCell>
+                    <TableCell><strong>상세 설명</strong></TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {program.exerciseSchedule.map((schedule) => (
+                    <TableRow key={schedule.day}>
+                      <TableCell>{schedule.day}</TableCell>
+                      <TableCell>
+                        <Typography variant="body2" fontWeight="bold">
+                          {schedule.exercise}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" color="text.secondary">
+                          {schedule.description}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Paper>
+        )}
+
+        {/* 식단 가이드 탭 */}
+        {tabValue === 1 && (
+          <Paper elevation={2} sx={{ p: 3 }}>
+            <Typography variant="h6" fontWeight="bold" gutterBottom>
+              {selectedWeek}주차 식단 가이드
+            </Typography>
+            {program.nutritionGuide.map((guide) => (
+              <Box key={guide.day} sx={{ mb: 3, pb: 2, borderBottom: '1px solid #e0e0e0' }}>
+                <Typography variant="subtitle1" fontWeight="bold" color="primary" gutterBottom>
+                  {guide.day}
+                </Typography>
+                <Box sx={{ ml: 2 }}>
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    <strong>아침:</strong> {guide.meals.breakfast}
+                  </Typography>
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    <strong>점심:</strong> {guide.meals.lunch}
+                  </Typography>
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    <strong>저녁:</strong> {guide.meals.dinner}
+                  </Typography>
+                  {guide.meals.snacks && guide.meals.snacks.length > 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                      <strong>간식:</strong> {guide.meals.snacks.join(', ')}
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+            ))}
+          </Paper>
+        )}
+
+        {/* 주간 목표 */}
+        <Paper elevation={2} sx={{ p: 3, mt: 3 }}>
+          <Typography variant="h6" fontWeight="bold" gutterBottom>
+            {selectedWeek}주차 목표
+          </Typography>
+          <List>
+            {program.weeklyGoals.map((goal, index) => (
+              <ListItem key={index}>
+                <ListItemText
+                  primary={goal}
+                  primaryTypographyProps={{ variant: 'body2' }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Paper>
+
+        {/* 안내 */}
+        <Box sx={{ mt: 3, p: 2, bgcolor: 'warning.50', borderRadius: 1, border: '1px solid', borderColor: 'warning.200' }}>
+          <Typography variant="body2" color="text.secondary">
+            <strong>주의:</strong> 이 프로그램은 일반적인 가이드입니다. 개인의 건강 상태에 따라 조정이 필요할 수 있으며,
+            운동 중 불편함이나 통증이 있다면 즉시 중단하고 의료 전문가와 상담하세요.
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,5 +1,5 @@
 // 파일 경로: app/signup/page.tsx
-// 설명: 회원가입 페이지
+// 설명: v2.0 회원가입 - 초기 체중/허리둘레/목표 입력 추가
 
 'use client';
 
@@ -16,6 +16,9 @@ import {
   Link as MuiLink,
   InputAdornment,
   IconButton,
+  Stepper,
+  Step,
+  StepLabel,
 } from '@mui/material';
 import {
   PersonAdd,
@@ -23,40 +26,113 @@ import {
   Lock,
   Visibility,
   VisibilityOff,
+  FitnessCenter,
+  ArrowForward,
+  ArrowBack,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { signup } from '@/lib/auth';
+import { getTodayString } from '@/lib/dateUtils';
 
 /**
- * SignupPage 컴포넌트
+ * SignupPage v2.0
  * 
- * 기능:
- * - 이메일/비밀번호/비밀번호 확인 입력
- * - 회원가입 처리
- * - 로그인 페이지로 이동
- * - 회원가입 시 자동으로 12주 프로그램 시작
+ * 2단계 회원가입:
+ * Step 1: 이메일/비밀번호
+ * Step 2: 초기 체중/허리둘레, 목표 설정
  */
 export default function SignupPage() {
   const router = useRouter();
 
-  // === 상태 관리 ===
+  // 단계 관리 (0: 계정정보, 1: 신체정보)
+  const [activeStep, setActiveStep] = useState(0);
+
+  // Step 1: 계정 정보
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  // Step 2: 신체 정보
+  const [initialWeight, setInitialWeight] = useState('');
+  const [targetWeight, setTargetWeight] = useState('');
+  const [initialWaist, setInitialWaist] = useState('');
+  const [targetWaist, setTargetWaist] = useState('');
+
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
+  const steps = ['계정 정보', '신체 정보 & 목표'];
+
   /**
-   * 회원가입 폼 제출 핸들러
+   * Step 1 다음 버튼
    */
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
+  const handleNextStep = () => {
     // 입력값 검증
     if (!email || !password || !confirmPassword) {
       setError('모든 항목을 입력해주세요');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('비밀번호는 최소 6자 이상이어야 합니다');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('비밀번호가 일치하지 않습니다');
+      return;
+    }
+
+    setError('');
+    setActiveStep(1);
+  };
+
+  /**
+   * Step 2 회원가입 완료
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // 신체 정보 검증
+    const weight = parseFloat(initialWeight);
+    const target = parseFloat(targetWeight);
+    const waist = parseFloat(initialWaist);
+    const targetW = parseFloat(targetWaist);
+
+    if (!weight || !target || !waist || !targetW) {
+      setError('모든 신체 정보를 입력해주세요');
+      return;
+    }
+
+    if (weight <= 0 || weight > 300) {
+      setError('현재 체중을 올바르게 입력해주세요 (1-300kg)');
+      return;
+    }
+
+    if (target <= 0 || target > 300) {
+      setError('목표 체중을 올바르게 입력해주세요 (1-300kg)');
+      return;
+    }
+
+    if (waist <= 0 || waist > 200) {
+      setError('현재 허리둘레를 올바르게 입력해주세요 (1-200cm)');
+      return;
+    }
+
+    if (targetW <= 0 || targetW > 200) {
+      setError('목표 허리둘레를 올바르게 입력해주세요 (1-200cm)');
+      return;
+    }
+
+    if (target >= weight) {
+      setError('목표 체중은 현재 체중보다 작아야 합니다');
+      return;
+    }
+
+    if (targetW >= waist) {
+      setError('목표 허리둘레는 현재 허리둘레보다 작아야 합니다');
       return;
     }
 
@@ -64,14 +140,20 @@ export default function SignupPage() {
     setError('');
 
     // 회원가입 처리
-    const result = signup(email, password, confirmPassword);
+    const result = signup(
+      email,
+      password,
+      confirmPassword,
+      getTodayString(), // 시작일: 오늘
+      weight,
+      target,
+      waist,
+      targetW
+    );
 
     if (result.success) {
-      // 회원가입 성공 - 메인 페이지로 이동
-      // (회원가입 시 자동 로그인됨)
       router.push('/');
     } else {
-      // 회원가입 실패 - 오류 메시지 표시
       setError(result.message);
       setLoading(false);
     }
@@ -79,24 +161,26 @@ export default function SignupPage() {
 
   return (
     <Container maxWidth="sm" sx={{ minHeight: '100vh', display: 'flex', alignItems: 'center', py: 4 }}>
-      <Paper
-        elevation={3}
-        sx={{
-          p: 4,
-          width: '100%',
-          borderRadius: 3,
-        }}
-      >
+      <Paper elevation={3} sx={{ p: 4, width: '100%', borderRadius: 3 }}>
         {/* 헤더 */}
-        <Box sx={{ textAlign: 'center', mb: 4 }}>
+        <Box sx={{ textAlign: 'center', mb: 3 }}>
           <PersonAdd sx={{ fontSize: 48, color: 'primary.main', mb: 1 }} />
           <Typography variant="h4" fontWeight="bold" gutterBottom>
             회원가입
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            12주 건강 여정을 함께 시작해요!
+            12주 건강 여정을 시작합니다
           </Typography>
         </Box>
+
+        {/* 진행 단계 표시 */}
+        <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
 
         {/* 오류 메시지 */}
         {error && (
@@ -105,125 +189,198 @@ export default function SignupPage() {
           </Alert>
         )}
 
-        {/* 회원가입 폼 */}
-        <form onSubmit={handleSubmit}>
-          {/* 이메일 입력 */}
-          <TextField
-            fullWidth
-            label="이메일"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="example@email.com"
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Email color="action" />
-                </InputAdornment>
-              ),
-            }}
-          />
+        {/* Step 1: 계정 정보 */}
+        {activeStep === 0 && (
+          <Box>
+            <TextField
+              fullWidth
+              label="이메일"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="example@email.com"
+              sx={{ mb: 2 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Email color="action" />
+                  </InputAdornment>
+                ),
+              }}
+            />
 
-          {/* 비밀번호 입력 */}
-          <TextField
-            fullWidth
-            label="비밀번호"
-            type={showPassword ? 'text' : 'password'}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="최소 6자 이상"
-            sx={{ mb: 2 }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Lock color="action" />
-                </InputAdornment>
-              ),
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    onClick={() => setShowPassword(!showPassword)}
-                    edge="end"
-                  >
-                    {showPassword ? <VisibilityOff /> : <Visibility />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-            helperText="6자 이상 입력해주세요"
-          />
+            <TextField
+              fullWidth
+              label="비밀번호"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="최소 6자 이상"
+              sx={{ mb: 2 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Lock color="action" />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowPassword(!showPassword)} edge="end">
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+              helperText="6자 이상 입력해주세요"
+            />
 
-          {/* 비밀번호 확인 입력 */}
-          <TextField
-            fullWidth
-            label="비밀번호 확인"
-            type={showConfirmPassword ? 'text' : 'password'}
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            placeholder="비밀번호를 다시 입력하세요"
-            sx={{ mb: 3 }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Lock color="action" />
-                </InputAdornment>
-              ),
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    edge="end"
-                  >
-                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
+            <TextField
+              fullWidth
+              label="비밀번호 확인"
+              type={showConfirmPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="비밀번호를 다시 입력하세요"
+              sx={{ mb: 3 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <Lock color="action" />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end">
+                      {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
 
-          {/* 회원가입 버튼 */}
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-            size="large"
-            disabled={loading}
-            sx={{
-              py: 1.5,
-              fontWeight: 'bold',
-              mb: 2,
-            }}
-          >
-            {loading ? '가입 중...' : '회원가입'}
-          </Button>
-
-          {/* 로그인 링크 */}
-          <Box sx={{ textAlign: 'center' }}>
-            <Typography variant="body2" color="text.secondary">
-              이미 계정이 있으신가요?{' '}
-              <MuiLink
-                component={Link}
-                href="/login"
-                sx={{
-                  fontWeight: 'bold',
-                  textDecoration: 'none',
-                  '&:hover': {
-                    textDecoration: 'underline',
-                  },
-                }}
-              >
-                로그인
-              </MuiLink>
-            </Typography>
+            <Button
+              variant="contained"
+              fullWidth
+              size="large"
+              endIcon={<ArrowForward />}
+              onClick={handleNextStep}
+              sx={{ py: 1.5, fontWeight: 'bold' }}
+            >
+              다음 단계
+            </Button>
           </Box>
-        </form>
+        )}
 
-        {/* 안내 문구 */}
-        <Box sx={{ mt: 3, p: 2, bgcolor: 'info.50', borderRadius: 1, border: '1px solid', borderColor: 'info.200' }}>
-          <Typography variant="caption" color="text.secondary">
-            ℹ️ <strong>알림:</strong> 회원가입과 동시에 12주 건강관리 프로그램이 시작됩니다.
-            오늘이 1일차가 됩니다!
+        {/* Step 2: 신체 정보 */}
+        {activeStep === 1 && (
+          <form onSubmit={handleSubmit}>
+            <Typography variant="subtitle1" fontWeight="bold" gutterBottom sx={{ mb: 2 }}>
+              현재 신체 정보
+            </Typography>
+
+            <TextField
+              fullWidth
+              label="현재 체중 (kg)"
+              value={initialWeight}
+              onChange={(e) => setInitialWeight(e.target.value)}
+              placeholder="예: 83.6"
+              type="number"
+              inputProps={{ step: '0.1', min: '1', max: '300' }}
+              sx={{ mb: 2 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <FitnessCenter color="action" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            <TextField
+              fullWidth
+              label="현재 허리둘레 (cm)"
+              value={initialWaist}
+              onChange={(e) => setInitialWaist(e.target.value)}
+              placeholder="예: 87.7"
+              type="number"
+              inputProps={{ step: '0.1', min: '1', max: '200' }}
+              sx={{ mb: 3 }}
+            />
+
+            <Typography variant="subtitle1" fontWeight="bold" gutterBottom sx={{ mb: 2 }}>
+              12주 후 목표
+            </Typography>
+
+            <TextField
+              fullWidth
+              label="목표 체중 (kg)"
+              value={targetWeight}
+              onChange={(e) => setTargetWeight(e.target.value)}
+              placeholder="예: 78"
+              type="number"
+              inputProps={{ step: '0.1', min: '1', max: '300' }}
+              sx={{ mb: 2 }}
+              helperText="현재 체중보다 낮게 설정하세요"
+            />
+
+            <TextField
+              fullWidth
+              label="목표 허리둘레 (cm)"
+              value={targetWaist}
+              onChange={(e) => setTargetWaist(e.target.value)}
+              placeholder="예: 85"
+              type="number"
+              inputProps={{ step: '0.1', min: '1', max: '200' }}
+              sx={{ mb: 3 }}
+              helperText="현재 허리둘레보다 낮게 설정하세요"
+            />
+
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button
+                variant="outlined"
+                fullWidth
+                startIcon={<ArrowBack />}
+                onClick={() => setActiveStep(0)}
+                sx={{ py: 1.5 }}
+              >
+                이전
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                fullWidth
+                size="large"
+                disabled={loading}
+                sx={{ py: 1.5, fontWeight: 'bold' }}
+              >
+                {loading ? '가입 중...' : '회원가입 완료'}
+              </Button>
+            </Box>
+          </form>
+        )}
+
+        {/* 로그인 링크 */}
+        <Box sx={{ textAlign: 'center', mt: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            이미 계정이 있으신가요?{' '}
+            <MuiLink
+              component={Link}
+              href="/login"
+              sx={{
+                fontWeight: 'bold',
+                textDecoration: 'none',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              로그인
+            </MuiLink>
+          </Typography>
+        </Box>
+
+        {/* 안내 */}
+        <Box sx={{ mt: 3, p: 2, bgcolor: 'info.main', borderRadius: 1, color: 'white' }}>
+          <Typography variant="caption">
+            회원가입과 동시에 12주 프로그램이 시작됩니다. 오늘이 1주차 1일차입니다!
           </Typography>
         </Box>
       </Paper>

--- a/components/DailyCheckForm.tsx
+++ b/components/DailyCheckForm.tsx
@@ -1,12 +1,11 @@
 // 파일 경로: components/DailyCheckForm.tsx
-// 설명: 일일 체크리스트 입력 폼 컴포넌트
+// 설명: v2.0 일일 체크리스트 (12개 항목 입력)
 
 'use client';
 
 import React, { useState, useEffect } from 'react';
 import {
   Box,
-  Paper,
   Typography,
   Checkbox,
   FormControlLabel,
@@ -14,35 +13,42 @@ import {
   Button,
   Alert,
   Snackbar,
+  Divider,
+  Slider,
+  Chip,
+  Grid,
 } from '@mui/material';
-import { Save, FitnessCenter, Restaurant, Scale } from '@mui/icons-material';
+import {
+  Save,
+  Restaurant,
+  LocalDrink,
+  FitnessCenter,
+  Bedtime,
+  Scale,
+  StraightenOutlined,
+  SentimentSatisfied,
+} from '@mui/icons-material';
 import type { DailyCheck } from '@/types';
-import { validateWeight } from '@/lib/auth';
 import { getDayName } from '@/lib/dateUtils';
 
-/**
- * DailyCheckForm 컴포넌트의 props 타입
- */
 interface DailyCheckFormProps {
-  date: string;                           // 기록할 날짜 (YYYY-MM-DD)
-  initialData: DailyCheck | null;         // 기존 데이터 (수정 모드일 때)
-  onSave: (check: DailyCheck) => void;    // 저장 완료 콜백
-  onCancel?: () => void;                  // 취소 콜백
+  date: string;
+  initialData: DailyCheck | null;
+  onSave: (check: DailyCheck) => void;
+  onCancel?: () => void;
 }
 
 /**
- * DailyCheckForm 컴포넌트
+ * DailyCheckForm v2.0
  * 
- * 기능:
- * - 운동 완료 여부 체크박스
- * - 식단 준수 여부 체크박스
- * - 체중 입력 필드
- * - 저장/취소 버튼
- * - 입력값 유효성 검사
- * 
- * React Hooks 사용:
- * - useState: 폼 상태 관리
- * - useEffect: 초기 데이터 로드
+ * 12개 체크 항목:
+ * 1-3. 식사 (아침/점심/저녁) + 시간
+ * 4. 물 섭취 (8잔)
+ * 5-7. 운동 (완료/종류/시간)
+ * 8. 수면 시간
+ * 9-10. 체중/허리둘레
+ * 11. 컨디션 (1-10)
+ * 12. 메모
  */
 export default function DailyCheckForm({
   date,
@@ -50,171 +56,388 @@ export default function DailyCheckForm({
   onSave,
   onCancel,
 }: DailyCheckFormProps) {
-  // === 상태 관리 ===
-  // useState는 컴포넌트의 상태를 관리하는 React Hook입니다
-  
-  // 운동 완료 여부
+  // 식사
+  const [breakfastCompleted, setBreakfastCompleted] = useState(false);
+  const [breakfastTime, setBreakfastTime] = useState('07:00');
+  const [lunchCompleted, setLunchCompleted] = useState(false);
+  const [lunchTime, setLunchTime] = useState('12:00');
+  const [dinnerCompleted, setDinnerCompleted] = useState(false);
+  const [dinnerTime, setDinnerTime] = useState('18:00');
+
+  // 물 섭취 (0-8잔)
+  const [waterIntake, setWaterIntake] = useState(0);
+
+  // 운동
   const [exerciseCompleted, setExerciseCompleted] = useState(false);
-  
-  // 식단 준수 여부
-  const [dietCompleted, setDietCompleted] = useState(false);
-  
-  // 체중 (문자열로 관리, 입력 중 빈 값 허용)
+  const [exerciseType, setExerciseType] = useState('');
+  const [exerciseDuration, setExerciseDuration] = useState('');
+
+  // 수면
+  const [sleepHours, setSleepHours] = useState('');
+
+  // 신체 측정
   const [weight, setWeight] = useState('');
-  
-  // 오류 메시지
+  const [waistCircumference, setWaistCircumference] = useState('');
+
+  // 컨디션 (1-10)
+  const [condition, setCondition] = useState(5);
+
+  // 메모
+  const [memo, setMemo] = useState('');
+
   const [error, setError] = useState('');
-  
-  // 성공 메시지 표시 여부
   const [showSuccess, setShowSuccess] = useState(false);
 
-  // === 초기 데이터 로드 ===
-  // useEffect는 컴포넌트가 렌더링될 때 실행되는 React Hook입니다
+  // 초기 데이터 로드
   useEffect(() => {
     if (initialData) {
-      // 기존 데이터가 있으면 폼에 채우기
+      setBreakfastCompleted(initialData.breakfastCompleted);
+      setBreakfastTime(initialData.breakfastTime || '07:00');
+      setLunchCompleted(initialData.lunchCompleted);
+      setLunchTime(initialData.lunchTime || '12:00');
+      setDinnerCompleted(initialData.dinnerCompleted);
+      setDinnerTime(initialData.dinnerTime || '18:00');
+      setWaterIntake(initialData.waterIntake);
       setExerciseCompleted(initialData.exerciseCompleted);
-      setDietCompleted(initialData.dietCompleted);
-      setWeight(initialData.weight !== null ? String(initialData.weight) : '');
+      setExerciseType(initialData.exerciseType || '');
+      setExerciseDuration(initialData.exerciseDuration ? String(initialData.exerciseDuration) : '');
+      setSleepHours(initialData.sleepHours ? String(initialData.sleepHours) : '');
+      setWeight(initialData.weight ? String(initialData.weight) : '');
+      setWaistCircumference(initialData.waistCircumference ? String(initialData.waistCircumference) : '');
+      setCondition(initialData.condition || 5);
+      setMemo(initialData.memo || '');
     }
-  }, [initialData]); // initialData가 변경될 때마다 실행
+  }, [initialData]);
 
   /**
-   * 저장 버튼 클릭 핸들러
-   * 
-   * 동작 순서:
-   * 1. 체중 유효성 검사
-   * 2. DailyCheck 객체 생성
-   * 3. onSave 콜백 호출
-   * 4. 성공 메시지 표시
+   * 저장 핸들러
    */
   const handleSave = () => {
-    // 1. 체중 입력값 처리
-    const weightValue = weight.trim() === '' ? null : parseFloat(weight);
-    
-    // 2. 체중 유효성 검사
-    const validation = validateWeight(weightValue);
-    if (!validation.valid) {
-      setError(validation.message);
-      return;
-    }
-
-    // 3. DailyCheck 객체 생성
     const checkData: DailyCheck = {
       date,
+      breakfastCompleted,
+      breakfastTime: breakfastCompleted ? breakfastTime : undefined,
+      lunchCompleted,
+      lunchTime: lunchCompleted ? lunchTime : undefined,
+      dinnerCompleted,
+      dinnerTime: dinnerCompleted ? dinnerTime : undefined,
+      waterIntake,
       exerciseCompleted,
-      dietCompleted,
-      weight: weightValue,
+      exerciseType: exerciseCompleted ? exerciseType : undefined,
+      exerciseDuration: exerciseCompleted && exerciseDuration ? parseFloat(exerciseDuration) : undefined,
+      sleepHours: sleepHours ? parseFloat(sleepHours) : undefined,
+      weight: weight ? parseFloat(weight) : undefined,
+      waistCircumference: waistCircumference ? parseFloat(waistCircumference) : undefined,
+      condition,
+      memo: memo.trim() || undefined,
     };
 
-    // 4. 부모 컴포넌트에 데이터 전달
     onSave(checkData);
-    
-    // 5. 성공 메시지 표시
     setShowSuccess(true);
     setError('');
   };
 
   /**
-   * 체중 입력 핸들러
-   * - 숫자와 소수점만 허용
+   * 완료율 계산 (12개 항목 중)
    */
-  const handleWeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    // 숫자와 소수점만 허용하는 정규표현식
-    if (value === '' || /^\d*\.?\d*$/.test(value)) {
-      setWeight(value);
-      setError(''); // 오류 메시지 초기화
-    }
+  const calculateCompletionRate = (): number => {
+    let completed = 0;
+    if (breakfastCompleted) completed++;
+    if (lunchCompleted) completed++;
+    if (dinnerCompleted) completed++;
+    if (waterIntake >= 8) completed++;
+    if (exerciseCompleted) completed++;
+    if (sleepHours) completed++;
+    if (weight) completed++;
+    if (waistCircumference) completed++;
+    if (condition) completed++;
+    if (memo) completed++;
+    return Math.round((completed / 10) * 100); // 메모/컨디션은 선택이므로 10개 기준
   };
+
+  const completionRate = calculateCompletionRate();
 
   return (
     <>
-      <Paper elevation={3} sx={{ p: 3, borderRadius: 2 }}>
-        {/* 헤더: 날짜 표시 */}
+      <Box sx={{ py: 2 }}>
+        {/* 헤더 */}
         <Box sx={{ mb: 3 }}>
-          <Typography variant="h6" fontWeight="bold" gutterBottom>
+          <Typography variant="h6" fontWeight="bold">
             {date} ({getDayName(date)})
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            오늘의 건강 기록을 입력해주세요
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              완료율:
+            </Typography>
+            <Chip
+              label={`${completionRate}%`}
+              size="small"
+              color={completionRate >= 80 ? 'success' : completionRate >= 50 ? 'warning' : 'default'}
+            />
+          </Box>
         </Box>
 
-        {/* 오류 메시지 */}
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
             {error}
           </Alert>
         )}
 
-        {/* 체크박스들 */}
+        {/* 1. 식사 체크 */}
         <Box sx={{ mb: 3 }}>
-          {/* 운동 완료 체크박스 */}
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <Restaurant sx={{ mr: 1, color: 'primary.main' }} />
+            <Typography variant="subtitle1" fontWeight="bold">
+              식사 체크
+            </Typography>
+          </Box>
+
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={breakfastCompleted}
+                    onChange={(e) => setBreakfastCompleted(e.target.checked)}
+                  />
+                }
+                label="아침"
+              />
+              {breakfastCompleted && (
+                <TextField
+                  type="time"
+                  size="small"
+                  value={breakfastTime}
+                  onChange={(e) => setBreakfastTime(e.target.value)}
+                  sx={{ ml: 4, width: 120 }}
+                />
+              )}
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={lunchCompleted}
+                    onChange={(e) => setLunchCompleted(e.target.checked)}
+                  />
+                }
+                label="점심"
+              />
+              {lunchCompleted && (
+                <TextField
+                  type="time"
+                  size="small"
+                  value={lunchTime}
+                  onChange={(e) => setLunchTime(e.target.value)}
+                  sx={{ ml: 4, width: 120 }}
+                />
+              )}
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={dinnerCompleted}
+                    onChange={(e) => setDinnerCompleted(e.target.checked)}
+                  />
+                }
+                label="저녁"
+              />
+              {dinnerCompleted && (
+                <TextField
+                  type="time"
+                  size="small"
+                  value={dinnerTime}
+                  onChange={(e) => setDinnerTime(e.target.value)}
+                  sx={{ ml: 4, width: 120 }}
+                />
+              )}
+            </Grid>
+          </Grid>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 2. 물 섭취 */}
+        <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <LocalDrink sx={{ mr: 1, color: 'info.main' }} />
+            <Typography variant="subtitle1" fontWeight="bold">
+              물 섭취: {waterIntake}/8잔
+            </Typography>
+          </Box>
+          <Slider
+            value={waterIntake}
+            onChange={(_, value) => setWaterIntake(value as number)}
+            min={0}
+            max={8}
+            marks
+            step={1}
+            valueLabelDisplay="auto"
+          />
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 3. 운동 */}
+        <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <FitnessCenter sx={{ mr: 1, color: 'success.main' }} />
+            <Typography variant="subtitle1" fontWeight="bold">
+              운동
+            </Typography>
+          </Box>
+
           <FormControlLabel
             control={
               <Checkbox
                 checked={exerciseCompleted}
                 onChange={(e) => setExerciseCompleted(e.target.checked)}
-                color="primary"
               />
             }
-            label={
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <FitnessCenter sx={{ mr: 1, color: 'primary.main' }} />
-                <Typography>운동 완료</Typography>
-              </Box>
-            }
-            sx={{ mb: 2, display: 'flex', width: '100%' }}
+            label="오늘 운동 완료"
+            sx={{ mb: 2 }}
           />
 
-          {/* 식단 준수 체크박스 */}
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={dietCompleted}
-                onChange={(e) => setDietCompleted(e.target.checked)}
-                color="success"
+          {exerciseCompleted && (
+            <Box sx={{ ml: 4 }}>
+              <TextField
+                fullWidth
+                label="운동 종류"
+                value={exerciseType}
+                onChange={(e) => setExerciseType(e.target.value)}
+                placeholder="예: 유산소 30분, 근력운동"
+                size="small"
+                sx={{ mb: 2 }}
               />
-            }
-            label={
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <Restaurant sx={{ mr: 1, color: 'success.main' }} />
-                <Typography>식단 준수</Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', width: '100%' }}
-          />
+              <TextField
+                fullWidth
+                label="운동 시간 (분)"
+                type="number"
+                value={exerciseDuration}
+                onChange={(e) => setExerciseDuration(e.target.value)}
+                placeholder="예: 40"
+                size="small"
+                inputProps={{ min: 1, max: 300 }}
+              />
+            </Box>
+          )}
         </Box>
 
-        {/* 체중 입력 */}
+        <Divider sx={{ my: 2 }} />
+
+        {/* 4. 수면 */}
         <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <Bedtime sx={{ mr: 1, color: 'secondary.main' }} />
+            <Typography variant="subtitle1" fontWeight="bold">
+              수면
+            </Typography>
+          </Box>
           <TextField
             fullWidth
-            label="체중 (kg)"
-            value={weight}
-            onChange={handleWeightChange}
-            placeholder="예: 70.5"
-            type="text"
-            inputMode="decimal"
-            InputProps={{
-              startAdornment: <Scale sx={{ mr: 1, color: 'text.secondary' }} />,
-            }}
-            helperText="체중을 입력하지 않으려면 비워두세요"
+            label="수면 시간 (시간)"
+            type="number"
+            value={sleepHours}
+            onChange={(e) => setSleepHours(e.target.value)}
+            placeholder="예: 7.5"
+            size="small"
+            inputProps={{ step: 0.5, min: 0, max: 24 }}
+            helperText="소수점 입력 가능 (예: 7.5시간)"
           />
         </Box>
 
-        {/* 버튼들 */}
+        <Divider sx={{ my: 2 }} />
+
+        {/* 5. 신체 측정 */}
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+            신체 측정
+          </Typography>
+
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                label="체중 (kg)"
+                value={weight}
+                onChange={(e) => setWeight(e.target.value)}
+                placeholder="예: 78.5"
+                type="number"
+                size="small"
+                inputProps={{ step: 0.1, min: 1, max: 300 }}
+                InputProps={{
+                  startAdornment: <Scale sx={{ mr: 1, color: 'text.secondary' }} />,
+                }}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                label="허리둘레 (cm)"
+                value={waistCircumference}
+                onChange={(e) => setWaistCircumference(e.target.value)}
+                placeholder="예: 85.5"
+                type="number"
+                size="small"
+                inputProps={{ step: 0.1, min: 1, max: 200 }}
+                InputProps={{
+                  startAdornment: <StraightenOutlined sx={{ mr: 1, color: 'text.secondary' }} />,
+                }}
+              />
+            </Grid>
+          </Grid>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 6. 컨디션 */}
+        <Box sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <SentimentSatisfied sx={{ mr: 1, color: 'warning.main' }} />
+            <Typography variant="subtitle1" fontWeight="bold">
+              오늘의 컨디션: {condition}/10
+            </Typography>
+          </Box>
+          <Slider
+            value={condition}
+            onChange={(_, value) => setCondition(value as number)}
+            min={1}
+            max={10}
+            marks
+            step={1}
+            valueLabelDisplay="auto"
+          />
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 7. 메모 */}
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+            오늘의 메모
+          </Typography>
+          <TextField
+            fullWidth
+            multiline
+            rows={3}
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            placeholder="오늘 하루 어떠셨나요? 특별한 일이나 느낌을 기록해보세요."
+          />
+        </Box>
+
+        {/* 버튼 */}
         <Box sx={{ display: 'flex', gap: 2 }}>
           <Button
             variant="contained"
             fullWidth
             startIcon={<Save />}
             onClick={handleSave}
-            sx={{
-              py: 1.5,
-              fontWeight: 'bold',
-            }}
+            sx={{ py: 1.5, fontWeight: 'bold' }}
           >
             저장하기
           </Button>
@@ -230,16 +453,9 @@ export default function DailyCheckForm({
             </Button>
           )}
         </Box>
+      </Box>
 
-        {/* 안내 문구 */}
-        <Box sx={{ mt: 2, p: 2, bgcolor: 'grey.50', borderRadius: 1 }}>
-          <Typography variant="caption" color="text.secondary">
-            💡 <strong>팁:</strong> 모든 항목을 완료하면 달력에 초록색으로 표시됩니다!
-          </Typography>
-        </Box>
-      </Paper>
-
-      {/* 성공 메시지 스낵바 */}
+      {/* 성공 메시지 */}
       <Snackbar
         open={showSuccess}
         autoHideDuration={3000}
@@ -247,7 +463,7 @@ export default function DailyCheckForm({
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert severity="success" sx={{ width: '100%' }}>
-          저장되었습니다! 🎉
+          저장되었습니다!
         </Alert>
       </Snackbar>
     </>

--- a/components/HealthMetrics.tsx
+++ b/components/HealthMetrics.tsx
@@ -1,0 +1,189 @@
+// 파일 경로: components/HealthMetrics.tsx
+// 설명: 체중/허리둘레 추이 차트 (recharts 사용)
+
+'use client';
+
+import React from 'react';
+import { Box, Paper, Typography, ToggleButtonGroup, ToggleButton } from '@mui/material';
+import { TrendingDown, ShowChart } from '@mui/icons-material';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+import type { ChartDataPoint, User } from '@/types';
+
+interface HealthMetricsProps {
+  user: User;
+  chartData: ChartDataPoint[];
+}
+
+/**
+ * HealthMetrics 컴포넌트
+ * 
+ * 기능:
+ * - 체중 추이 그래프
+ * - 허리둘레 추이 그래프
+ * - 목표선 표시
+ * - 토글로 체중/허리둘레 전환
+ */
+export default function HealthMetrics({ user, chartData }: HealthMetricsProps) {
+  const [metric, setMetric] = React.useState<'weight' | 'waist'>('weight');
+
+  const handleMetricChange = (
+    _: React.MouseEvent<HTMLElement>,
+    newMetric: 'weight' | 'waist' | null,
+  ) => {
+    if (newMetric !== null) {
+      setMetric(newMetric);
+    }
+  };
+
+  // 차트 데이터 필터링 (값이 있는 것만)
+  const filteredData = chartData.filter((d) =>
+    metric === 'weight' ? d.weight !== undefined : d.waist !== undefined
+  );
+
+  // 최신 측정값
+  const latestData = filteredData[filteredData.length - 1];
+  const currentValue = metric === 'weight' ? latestData?.weight : latestData?.waist;
+  const targetValue = metric === 'weight' ? user.targetWeight : user.targetWaist;
+  const initialValue = metric === 'weight' ? user.initialWeight : user.initialWaist;
+
+  // 변화량 계산
+  const change = currentValue ? (initialValue - currentValue).toFixed(1) : '0';
+  const remaining = currentValue ? (currentValue - targetValue).toFixed(1) : '0';
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
+      {/* 헤더 */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <ShowChart sx={{ fontSize: 28, mr: 1, color: 'primary.main' }} />
+          <Typography variant="h6" fontWeight="bold">
+            건강 지표 추이
+          </Typography>
+        </Box>
+
+        {/* 토글 버튼 */}
+        <ToggleButtonGroup
+          value={metric}
+          exclusive
+          onChange={handleMetricChange}
+          size="small"
+        >
+          <ToggleButton value="weight">체중</ToggleButton>
+          <ToggleButton value="waist">허리둘레</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* 현재 상태 요약 */}
+      <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+        <Box sx={{ flex: 1, minWidth: 150, p: 2, bgcolor: 'primary.50', borderRadius: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            현재 {metric === 'weight' ? '체중' : '허리둘레'}
+          </Typography>
+          <Typography variant="h5" fontWeight="bold" color="primary.main">
+            {currentValue || initialValue}
+            {metric === 'weight' ? 'kg' : 'cm'}
+          </Typography>
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 150, p: 2, bgcolor: 'success.50', borderRadius: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            변화량
+          </Typography>
+          <Typography variant="h5" fontWeight="bold" color="success.main">
+            {change > '0' ? '-' : '+'}{Math.abs(parseFloat(change))}
+            {metric === 'weight' ? 'kg' : 'cm'}
+          </Typography>
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 150, p: 2, bgcolor: 'warning.50', borderRadius: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            목표까지
+          </Typography>
+          <Typography variant="h5" fontWeight="bold" color="warning.main">
+            {remaining}
+            {metric === 'weight' ? 'kg' : 'cm'}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* 차트 */}
+      {filteredData.length > 0 ? (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={filteredData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 12 }}
+              angle={-45}
+              textAnchor="end"
+              height={60}
+            />
+            <YAxis
+              domain={[
+                metric === 'weight'
+                  ? Math.floor(targetValue - 2)
+                  : Math.floor(targetValue - 5),
+                metric === 'weight'
+                  ? Math.ceil(initialValue + 2)
+                  : Math.ceil(initialValue + 5),
+              ]}
+              tick={{ fontSize: 12 }}
+            />
+            <Tooltip />
+            <Legend />
+
+            {/* 목표선 */}
+            <ReferenceLine
+              y={targetValue}
+              stroke="#FF9800"
+              strokeDasharray="5 5"
+              label={{ value: '목표', position: 'right', fill: '#FF9800' }}
+            />
+
+            {/* 실제 측정값 */}
+            <Line
+              type="monotone"
+              dataKey={metric === 'weight' ? 'weight' : 'waist'}
+              stroke="#2196F3"
+              strokeWidth={2}
+              dot={{ r: 4 }}
+              name={metric === 'weight' ? '체중 (kg)' : '허리둘레 (cm)'}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <Box
+          sx={{
+            height: 300,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'grey.50',
+            borderRadius: 1,
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            아직 측정 데이터가 없습니다. 체중과 허리둘레를 기록해보세요!
+          </Typography>
+        </Box>
+      )}
+
+      {/* 안내 */}
+      <Box sx={{ mt: 2, p: 2, bgcolor: 'grey.50', borderRadius: 1 }}>
+        <Typography variant="caption" color="text.secondary">
+          💡 <strong>팁:</strong> 매주 같은 시간(아침 공복)에 측정하면 정확한 추이를 확인할 수 있습니다.
+        </Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/components/PhaseIndicator.tsx
+++ b/components/PhaseIndicator.tsx
@@ -1,0 +1,109 @@
+// 파일 경로: components/PhaseIndicator.tsx
+// 설명: 현재 Phase 표시 컴포넌트
+
+'use client';
+
+import React from 'react';
+import { Box, Paper, Typography, Chip, LinearProgress } from '@mui/material';
+import { TrendingUp } from '@mui/icons-material';
+import { PHASE_INFO, PHASE_COLORS } from '@/lib/programData';
+import type { Phase } from '@/types';
+
+interface PhaseIndicatorProps {
+  currentWeek: number;
+  currentPhase: Phase;
+}
+
+/**
+ * PhaseIndicator 컴포넌트
+ * 
+ * 현재 Phase 정보 표시:
+ * - Phase 1/2/3 표시
+ * - 진행률 바
+ * - 집중 영역 표시
+ */
+export default function PhaseIndicator({ currentWeek, currentPhase }: PhaseIndicatorProps) {
+  const phaseInfo = PHASE_INFO[currentPhase];
+  
+  // Phase별 주차 범위
+  const phaseWeekRanges = {
+    1: { start: 1, end: 4 },
+    2: { start: 5, end: 8 },
+    3: { start: 9, end: 12 },
+  };
+  
+  const range = phaseWeekRanges[currentPhase];
+  const weekInPhase = currentWeek - range.start + 1;
+  const phaseProgress = (weekInPhase / 4) * 100;
+
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        p: 3,
+        mb: 3,
+        borderRadius: 2,
+        background: `linear-gradient(135deg, ${PHASE_COLORS[currentPhase]} 0%, ${PHASE_COLORS[currentPhase]}CC 100%)`,
+        color: 'white',
+      }}
+    >
+      {/* 헤더 */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <TrendingUp sx={{ fontSize: 32, mr: 1.5 }} />
+          <Typography variant="h5" fontWeight="bold">
+            {phaseInfo.title}
+          </Typography>
+        </Box>
+        <Chip
+          label={`${weekInPhase}/4주`}
+          sx={{ bgcolor: 'white', color: PHASE_COLORS[currentPhase], fontWeight: 'bold' }}
+        />
+      </Box>
+
+      {/* Phase 진행률 */}
+      <Box sx={{ mb: 2 }}>
+        <LinearProgress
+          variant="determinate"
+          value={phaseProgress}
+          sx={{
+            height: 10,
+            borderRadius: 5,
+            backgroundColor: 'rgba(255, 255, 255, 0.3)',
+            '& .MuiLinearProgress-bar': {
+              borderRadius: 5,
+              backgroundColor: 'white',
+            },
+          }}
+        />
+      </Box>
+
+      {/* 설명 */}
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        {phaseInfo.description}
+      </Typography>
+
+      {/* 집중 영역 */}
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        {phaseInfo.focusAreas.map((area) => (
+          <Chip
+            key={area}
+            label={area}
+            size="small"
+            sx={{ bgcolor: 'rgba(255, 255, 255, 0.2)', color: 'white' }}
+          />
+        ))}
+      </Box>
+
+      {/* 목표 */}
+      <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid rgba(255, 255, 255, 0.3)' }}>
+        <Typography variant="body2" sx={{ mb: 0.5 }}>
+          <strong>운동 목표:</strong> {phaseInfo.exerciseGoal}
+        </Typography>
+        <Typography variant="body2">
+          <strong>식단 목표:</strong> {phaseInfo.nutritionGoal}
+        </Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/components/WeeklyStats.tsx
+++ b/components/WeeklyStats.tsx
@@ -1,52 +1,24 @@
 // 파일 경로: components/WeeklyStats.tsx
-// 설명: 주차별 달성률 통계를 표시하는 컴포넌트
+// 설명: v2.0 주차별 통계 (Phase별 색상, 새로운 지표)
 
 'use client';
 
 import React from 'react';
-import { Box, Paper, Typography, Grid, Chip } from '@mui/material';
-import { TrendingUp, CheckCircle, Cancel } from '@mui/icons-material';
+import { Box, Paper, Typography, Grid, Chip, LinearProgress } from '@mui/material';
+import { TrendingUp, Restaurant, LocalDrink, FitnessCenter, Scale } from '@mui/icons-material';
+import { PHASE_COLORS } from '@/lib/programData';
 import type { WeeklyStats as WeeklyStatsType } from '@/types';
 
-/**
- * WeeklyStats 컴포넌트의 props 타입
- */
 interface WeeklyStatsProps {
-  weeklyData: WeeklyStatsType[]; // 12주간의 통계 데이터 배열
+  weeklyData: WeeklyStatsType[];
+  currentWeek: number;
 }
 
-/**
- * WeeklyStats 컴포넌트
- * 
- * 기능:
- * - 각 주차별 달성률 표시
- * - 완료/미완료 일수 표시
- * - 색상으로 달성도 시각화
- * 
- * 사용하는 MUI 컴포넌트:
- * - Grid: 반응형 레이아웃 (모바일에서는 1열, 태블릿 이상에서는 다열)
- * - Chip: 작은 정보 표시용 칩
- * - Paper: 카드 형태 컨테이너
- */
-export default function WeeklyStats({ weeklyData }: WeeklyStatsProps) {
-  /**
-   * 달성률에 따른 색상 반환
-   * - 80% 이상: 초록색 (성공)
-   * - 50% 이상: 노란색 (양호)
-   * - 50% 미만: 빨간색 (주의)
-   */
+export default function WeeklyStats({ weeklyData, currentWeek }: WeeklyStatsProps) {
   const getColorByRate = (rate: number): 'success' | 'warning' | 'error' => {
     if (rate >= 80) return 'success';
     if (rate >= 50) return 'warning';
     return 'error';
-  };
-
-  /**
-   * 달성률에 따른 아이콘 반환
-   */
-  const getIconByRate = (rate: number) => {
-    if (rate >= 80) return <CheckCircle sx={{ fontSize: 20 }} />;
-    return <Cancel sx={{ fontSize: 20 }} />;
   };
 
   return (
@@ -55,84 +27,109 @@ export default function WeeklyStats({ weeklyData }: WeeklyStatsProps) {
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
         <TrendingUp sx={{ fontSize: 28, mr: 1, color: 'primary.main' }} />
         <Typography variant="h6" fontWeight="bold">
-          주차별 달성 현황
+          주차별 상세 통계
         </Typography>
       </Box>
 
-      {/* 주차별 카드 그리드 */}
+      {/* 주차별 카드 */}
       <Grid container spacing={2}>
-        {weeklyData.map((week) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={week.weekNumber}>
-            <Paper
-              elevation={1}
-              sx={{
-                p: 2,
-                borderRadius: 2,
-                border: 2,
-                borderColor: `${getColorByRate(week.achievementRate)}.main`,
-                transition: 'all 0.3s',
-                '&:hover': {
-                  transform: 'translateY(-4px)',
-                  boxShadow: 4,
-                },
-              }}
-            >
-              {/* 주차 번호 */}
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <Typography variant="subtitle1" fontWeight="bold">
-                  {week.weekNumber}주차
-                </Typography>
-                {getIconByRate(week.achievementRate)}
-              </Box>
+        {weeklyData.map((week) => {
+          const isCurrentWeek = week.weekNumber === currentWeek;
+          const phaseColor = PHASE_COLORS[week.phase];
 
-              {/* 달성률 */}
-              <Typography
-                variant="h5"
-                fontWeight="bold"
-                color={`${getColorByRate(week.achievementRate)}.main`}
-                sx={{ mb: 1.5 }}
+          return (
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={week.weekNumber}>
+              <Paper
+                elevation={isCurrentWeek ? 4 : 1}
+                sx={{
+                  p: 2,
+                  borderRadius: 2,
+                  border: 2,
+                  borderColor: isCurrentWeek ? 'primary.main' : phaseColor,
+                  bgcolor: isCurrentWeek ? 'primary.50' : 'white',
+                  transition: 'all 0.3s',
+                  '&:hover': {
+                    transform: 'translateY(-4px)',
+                    boxShadow: 4,
+                  },
+                }}
               >
-                {week.achievementRate.toFixed(0)}%
-              </Typography>
+                {/* 헤더 */}
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                  <Typography variant="subtitle1" fontWeight="bold">
+                    {week.weekNumber}주차
+                  </Typography>
+                  <Chip
+                    label={`Phase ${week.phase}`}
+                    size="small"
+                    sx={{ bgcolor: phaseColor, color: 'white', fontWeight: 'bold' }}
+                  />
+                </Box>
 
-              {/* 상세 정보 */}
-              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                {/* 완료 일수 */}
-                <Chip
-                  label={`완료 ${week.completedDays}일`}
-                  size="small"
-                  color="success"
-                  variant="outlined"
-                />
-                {/* 일부 완료 */}
-                {week.partialDays > 0 && (
-                  <Chip
-                    label={`일부 ${week.partialDays}일`}
-                    size="small"
-                    color="warning"
-                    variant="outlined"
+                {/* 달성률 */}
+                <Box sx={{ mb: 2 }}>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      전체 달성률
+                    </Typography>
+                    <Typography variant="body2" fontWeight="bold" color={`${getColorByRate(week.achievementRate)}.main`}>
+                      {week.achievementRate.toFixed(0)}%
+                    </Typography>
+                  </Box>
+                  <LinearProgress
+                    variant="determinate"
+                    value={week.achievementRate}
+                    color={getColorByRate(week.achievementRate)}
+                    sx={{ height: 8, borderRadius: 4 }}
                   />
-                )}
-                {/* 미완료 일수 */}
-                {week.totalDays - week.completedDays - week.partialDays > 0 && (
-                  <Chip
-                    label={`미완료 ${week.totalDays - week.completedDays - week.partialDays}일`}
-                    size="small"
-                    color="error"
-                    variant="outlined"
-                  />
-                )}
-              </Box>
-            </Paper>
-          </Grid>
-        ))}
+                </Box>
+
+                {/* 상세 지표 */}
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {/* 식사 */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Restaurant sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Typography variant="caption">
+                      식사: {week.mealCompletionRate.toFixed(0)}%
+                    </Typography>
+                  </Box>
+
+                  {/* 물 */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <LocalDrink sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Typography variant="caption">
+                      물: {week.waterAverageIntake.toFixed(1)}잔/일
+                    </Typography>
+                  </Box>
+
+                  {/* 운동 */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <FitnessCenter sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Typography variant="caption">
+                      운동: {week.exerciseDays}일 ({week.totalExerciseMinutes}분)
+                    </Typography>
+                  </Box>
+
+                  {/* 체중 변화 */}
+                  {week.weightChange !== undefined && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Scale sx={{ fontSize: 16, color: 'text.secondary' }} />
+                      <Typography variant="caption" color="success.main" fontWeight="bold">
+                        체중: -{week.weightChange.toFixed(1)}kg
+                      </Typography>
+                    </Box>
+                  )}
+                </Box>
+              </Paper>
+            </Grid>
+          );
+        })}
       </Grid>
 
-      {/* 설명 */}
+      {/* 안내 */}
       <Box sx={{ mt: 3, p: 2, bgcolor: 'grey.50', borderRadius: 1 }}>
         <Typography variant="body2" color="text.secondary">
-          💡 <strong>팁:</strong> 각 주차를 클릭하면 해당 주의 상세 기록을 볼 수 있습니다.
-          80% 이상 달성하면 초록색으로 표시됩니다!
+          현재 진행 중인 주차는 파란색 테두리로 표시됩니다. Phase별로 색상이 구분됩니다.
         </Typography>
       </Box>
     </Paper>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,33 +1,19 @@
 // 파일 경로: lib/auth.ts
-// 설명: 사용자 인증 관련 함수 (로그인, 회원가입, 유효성 검사)
+// 설명: v2.0 인증 함수 (신체정보 추가)
 
 import { getUserByEmail, createUser, setCurrentUser } from './localStorage';
 import { getTodayString } from './dateUtils';
 
 /**
  * 이메일 유효성 검사
- * @param email - 검사할 이메일
- * @returns 유효하면 true
- * 
- * 검사 기준:
- * - 기본적인 이메일 형식 (example@domain.com)
- * - 정규표현식 사용
  */
 export function validateEmail(email: string): boolean {
-  // 이메일 정규표현식: 문자@문자.문자
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
 
 /**
  * 비밀번호 유효성 검사
- * @param password - 검사할 비밀번호
- * @returns { valid: boolean, message: string }
- * 
- * 검사 기준:
- * - 최소 6자 이상
- * - 실제 서비스에서는 더 강력한 규칙 적용 권장
- *   (대문자, 소문자, 숫자, 특수문자 포함 등)
  */
 export function validatePassword(password: string): { valid: boolean; message: string } {
   if (password.length < 6) {
@@ -37,122 +23,88 @@ export function validatePassword(password: string): { valid: boolean; message: s
     };
   }
   
-  return {
-    valid: true,
-    message: '',
-  };
+  return { valid: true, message: '' };
 }
 
 /**
- * 로그인 처리
- * @param email - 이메일
- * @param password - 비밀번호
- * @returns { success: boolean, message: string, userId?: string }
- * 
- * 동작 순서:
- * 1. 이메일로 사용자 찾기
- * 2. 비밀번호 확인
- * 3. 로그인 상태 저장
+ * 로그인 처리 (기존과 동일)
  */
 export function login(email: string, password: string): {
   success: boolean;
   message: string;
   userId?: string;
 } {
-  // 1. 이메일 유효성 검사
   if (!validateEmail(email)) {
-    return {
-      success: false,
-      message: '올바른 이메일 형식이 아닙니다',
-    };
+    return { success: false, message: '올바른 이메일 형식이 아닙니다' };
   }
 
-  // 2. 사용자 찾기
   const user = getUserByEmail(email);
   if (!user) {
-    return {
-      success: false,
-      message: '등록되지 않은 이메일입니다',
-    };
+    return { success: false, message: '등록되지 않은 이메일입니다' };
   }
 
-  // 3. 비밀번호 확인
-  // 실제 서비스에서는 해시 비교 필요 (bcrypt.compare)
   if (user.password !== password) {
-    return {
-      success: false,
-      message: '비밀번호가 일치하지 않습니다',
-    };
+    return { success: false, message: '비밀번호가 일치하지 않습니다' };
   }
 
-  // 4. 로그인 성공 - currentUser 설정
   setCurrentUser(user.id);
-
-  return {
-    success: true,
-    message: '로그인 성공',
-    userId: user.id,
-  };
+  return { success: true, message: '로그인 성공', userId: user.id };
 }
 
 /**
- * 회원가입 처리
- * @param email - 이메일
- * @param password - 비밀번호
- * @param confirmPassword - 비밀번호 확인
- * @returns { success: boolean, message: string, userId?: string }
- * 
- * 동작 순서:
- * 1. 입력값 유효성 검사
- * 2. 이메일 중복 확인
- * 3. 새 사용자 생성 (시작일: 오늘)
+ * 회원가입 처리 v2.0 (신체 정보 추가)
  */
 export function signup(
   email: string,
   password: string,
-  confirmPassword: string
+  confirmPassword: string,
+  startDate: string,
+  initialWeight: number,
+  targetWeight: number,
+  initialWaist: number,
+  targetWaist: number
 ): {
   success: boolean;
   message: string;
   userId?: string;
 } {
-  // 1. 이메일 유효성 검사
+  // 이메일 검증
   if (!validateEmail(email)) {
-    return {
-      success: false,
-      message: '올바른 이메일 형식이 아닙니다',
-    };
+    return { success: false, message: '올바른 이메일 형식이 아닙니다' };
   }
 
-  // 2. 비밀번호 유효성 검사
+  // 비밀번호 검증
   const passwordValidation = validatePassword(password);
   if (!passwordValidation.valid) {
-    return {
-      success: false,
-      message: passwordValidation.message,
-    };
+    return { success: false, message: passwordValidation.message };
   }
 
-  // 3. 비밀번호 확인
+  // 비밀번호 확인
   if (password !== confirmPassword) {
-    return {
-      success: false,
-      message: '비밀번호가 일치하지 않습니다',
-    };
+    return { success: false, message: '비밀번호가 일치하지 않습니다' };
   }
 
-  // 4. 이메일 중복 확인
+  // 이메일 중복 확인
   const existingUser = getUserByEmail(email);
   if (existingUser) {
-    return {
-      success: false,
-      message: '이미 등록된 이메일입니다',
-    };
+    return { success: false, message: '이미 등록된 이메일입니다' };
   }
 
-  // 5. 새 사용자 생성
-  // 시작일은 오늘로 설정
-  const newUser = createUser(email, password, getTodayString());
+  // 신체 정보 검증
+  if (initialWeight <= 0 || targetWeight <= 0 || initialWaist <= 0 || targetWaist <= 0) {
+    return { success: false, message: '신체 정보를 올바르게 입력해주세요' };
+  }
+
+  // 새 사용자 생성
+  const newUser = createUser(
+    email,
+    password,
+    startDate,
+    initialWeight,
+    targetWeight,
+    initialWaist,
+    targetWaist
+  );
 
   return {
     success: true,
@@ -163,34 +115,19 @@ export function signup(
 
 /**
  * 체중 유효성 검사
- * @param weight - 검사할 체중 (kg)
- * @returns { valid: boolean, message: string }
- * 
- * 검사 기준:
- * - 0보다 크고 300 이하 (합리적인 범위)
- * - 숫자 형식
  */
 export function validateWeight(weight: number | null): { valid: boolean; message: string } {
   if (weight === null) {
-    return { valid: true, message: '' }; // 체중 입력은 선택사항
+    return { valid: true, message: '' };
   }
 
   if (isNaN(weight)) {
-    return {
-      valid: false,
-      message: '올바른 숫자를 입력해주세요',
-    };
+    return { valid: false, message: '올바른 숫자를 입력해주세요' };
   }
 
   if (weight <= 0 || weight > 300) {
-    return {
-      valid: false,
-      message: '체중은 0보다 크고 300 이하여야 합니다',
-    };
+    return { valid: false, message: '체중은 0보다 크고 300 이하여야 합니다' };
   }
 
-  return {
-    valid: true,
-    message: '',
-  };
+  return { valid: true, message: '' };
 }

--- a/lib/localStorage.ts
+++ b/lib/localStorage.ts
@@ -1,33 +1,23 @@
 // 파일 경로: lib/localStorage.ts
-// 설명: 로컬 스토리지 데이터 관리 유틸리티 함수
-// 로컬 스토리지는 브라우저에 데이터를 저장하는 웹 API입니다
+// 설명: v2.0 로컬 스토리지 관리 (확장된 데이터 구조)
 
 import type { User, DailyCheck, LocalStorageData } from '@/types';
 
-// 로컬 스토리지 키 (데이터 저장 시 사용하는 고유 이름)
-const STORAGE_KEY = 'health-tracker-data';
+const STORAGE_KEY = 'health-tracker-v2-data';
 
 /**
- * 로컬 스토리지 초기 데이터 구조
- * - 앱 최초 실행 시 생성되는 기본 데이터
+ * 초기 데이터 구조
  */
 const initialData: LocalStorageData = {
-  currentUser: null,     // 로그인한 사용자 없음
-  users: {},             // 사용자 목록 비어있음
-  dailyChecks: {},       // 체크리스트 비어있음
+  currentUser: null,
+  users: {},
+  dailyChecks: {},
 };
 
 /**
- * 로컬 스토리지에서 전체 데이터 가져오기
- * @returns LocalStorageData 객체
- * 
- * 동작 원리:
- * 1. localStorage.getItem()으로 저장된 JSON 문자열 가져오기
- * 2. JSON.parse()로 문자열을 JavaScript 객체로 변환
- * 3. 데이터가 없으면 초기 데이터 반환
+ * 로컬 스토리지에서 데이터 가져오기
  */
 function getData(): LocalStorageData {
-  // 브라우저 환경 체크 (Next.js는 서버에서도 실행되므로)
   if (typeof window === 'undefined') {
     return initialData;
   }
@@ -35,7 +25,6 @@ function getData(): LocalStorageData {
   try {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) {
-      // 데이터가 없으면 초기 데이터를 저장하고 반환
       localStorage.setItem(STORAGE_KEY, JSON.stringify(initialData));
       return initialData;
     }
@@ -47,12 +36,7 @@ function getData(): LocalStorageData {
 }
 
 /**
- * 로컬 스토리지에 전체 데이터 저장
- * @param data - 저장할 데이터
- * 
- * 동작 원리:
- * 1. JavaScript 객체를 JSON.stringify()로 문자열로 변환
- * 2. localStorage.setItem()으로 저장
+ * 로컬 스토리지에 데이터 저장
  */
 function setData(data: LocalStorageData): void {
   if (typeof window === 'undefined') return;
@@ -65,8 +49,7 @@ function setData(data: LocalStorageData): void {
 }
 
 /**
- * 현재 로그인한 사용자 ID 가져오기
- * @returns 사용자 ID 또는 null
+ * 현재 사용자 ID 가져오기
  */
 export function getCurrentUserId(): string | null {
   const data = getData();
@@ -74,8 +57,7 @@ export function getCurrentUserId(): string | null {
 }
 
 /**
- * 현재 로그인한 사용자 정보 가져오기
- * @returns User 객체 또는 null
+ * 현재 사용자 정보 가져오기
  */
 export function getCurrentUser(): User | null {
   const data = getData();
@@ -84,11 +66,7 @@ export function getCurrentUser(): User | null {
 }
 
 /**
- * 사용자 로그인 처리
- * @param userId - 로그인할 사용자 ID
- * 
- * 동작:
- * - currentUser를 업데이트하여 로그인 상태 유지
+ * 로그인 처리
  */
 export function setCurrentUser(userId: string): void {
   const data = getData();
@@ -97,10 +75,7 @@ export function setCurrentUser(userId: string): void {
 }
 
 /**
- * 로그아웃 처리
- * 
- * 동작:
- * - currentUser를 null로 설정
+ * 로그아웃
  */
 export function logout(): void {
   const data = getData();
@@ -110,52 +85,43 @@ export function logout(): void {
 
 /**
  * 이메일로 사용자 찾기
- * @param email - 찾을 사용자 이메일
- * @returns User 객체 또는 null
- * 
- * 사용 예시: 로그인 시 이메일로 사용자 검색
  */
 export function getUserByEmail(email: string): User | null {
   const data = getData();
-  // Object.values()로 모든 사용자를 배열로 변환 후 검색
   const users = Object.values(data.users);
   return users.find(user => user.email === email) || null;
 }
 
 /**
- * 새 사용자 생성 (회원가입)
- * @param email - 이메일
- * @param password - 비밀번호
- * @param startDate - 12주 프로그램 시작일
- * @returns 생성된 User 객체
- * 
- * 동작:
- * 1. 고유 ID 생성 (타임스탬프 + 랜덤 문자열)
- * 2. 사용자 객체 생성
- * 3. 로컬 스토리지에 저장
- * 4. 자동 로그인 처리
+ * 새 사용자 생성 (v2.0 - 초기 체중/허리둘레 포함)
  */
-export function createUser(email: string, password: string, startDate: string): User {
+export function createUser(
+  email: string,
+  password: string,
+  startDate: string,
+  initialWeight: number,
+  targetWeight: number,
+  initialWaist: number,
+  targetWaist: number
+): User {
   const data = getData();
   
-  // 고유 ID 생성 (실제 서비스에서는 UUID 라이브러리 사용 권장)
   const userId = `user-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
   
   const newUser: User = {
     id: userId,
     email,
-    password, // 실제 서비스에서는 bcrypt 등으로 해시 처리 필요
+    password,
     startDate,
     createdAt: new Date().toISOString(),
+    initialWeight,
+    targetWeight,
+    initialWaist,
+    targetWaist,
   };
 
-  // 사용자 저장
   data.users[userId] = newUser;
-  
-  // 해당 사용자의 dailyChecks 초기화
   data.dailyChecks[userId] = {};
-  
-  // 자동 로그인
   data.currentUser = userId;
   
   setData(data);
@@ -164,9 +130,6 @@ export function createUser(email: string, password: string, startDate: string): 
 
 /**
  * 특정 날짜의 체크리스트 가져오기
- * @param userId - 사용자 ID
- * @param date - 날짜 (YYYY-MM-DD)
- * @returns DailyCheck 객체 또는 null
  */
 export function getDailyCheck(userId: string, date: string): DailyCheck | null {
   const data = getData();
@@ -174,37 +137,21 @@ export function getDailyCheck(userId: string, date: string): DailyCheck | null {
 }
 
 /**
- * 체크리스트 저장
- * @param userId - 사용자 ID
- * @param check - 저장할 체크리스트 데이터
- * 
- * 동작:
- * - 해당 날짜의 데이터를 업데이트 또는 생성
+ * 체크리스트 저장 (v2.0 - 12개 항목)
  */
 export function saveDailyCheck(userId: string, check: DailyCheck): void {
   const data = getData();
   
-  // 사용자의 dailyChecks가 없으면 초기화
   if (!data.dailyChecks[userId]) {
     data.dailyChecks[userId] = {};
   }
   
-  // 날짜별로 체크리스트 저장
   data.dailyChecks[userId][check.date] = check;
-  
   setData(data);
 }
 
 /**
- * 사용자의 모든 체크리스트 가져오기
- * @param userId - 사용자 ID
- * @returns 날짜를 키로 하는 DailyCheck 객체들
- * 
- * 반환 예시:
- * {
- *   '2025-01-01': { date: '2025-01-01', exerciseCompleted: true, ... },
- *   '2025-01-02': { date: '2025-01-02', exerciseCompleted: false, ... }
- * }
+ * 모든 체크리스트 가져오기
  */
 export function getAllDailyChecks(userId: string): { [date: string]: DailyCheck } {
   const data = getData();
@@ -212,9 +159,7 @@ export function getAllDailyChecks(userId: string): { [date: string]: DailyCheck 
 }
 
 /**
- * 특정 날짜의 체크리스트 삭제
- * @param userId - 사용자 ID
- * @param date - 삭제할 날짜
+ * 체크리스트 삭제
  */
 export function deleteDailyCheck(userId: string, date: string): void {
   const data = getData();
@@ -225,9 +170,7 @@ export function deleteDailyCheck(userId: string, date: string): void {
 }
 
 /**
- * 모든 데이터 초기화 (개발/테스트용)
- * 
- * 주의: 이 함수를 호출하면 모든 사용자 데이터가 삭제됩니다!
+ * 모든 데이터 초기화
  */
 export function clearAllData(): void {
   if (typeof window === 'undefined') return;

--- a/lib/programData.ts
+++ b/lib/programData.ts
@@ -1,0 +1,187 @@
+// 파일 경로: lib/programData.ts
+// 설명: 12주 건강개선 프로그램 데이터 (운동/식단 가이드)
+
+import type { PhaseInfo, WeeklyProgram, Phase } from '@/types';
+
+/**
+ * Phase별 기본 정보
+ */
+export const PHASE_INFO: Record<Phase, PhaseInfo> = {
+  1: {
+    phase: 1,
+    title: 'Phase 1: 기초 다지기',
+    weekRange: '1-4주',
+    description: '기초 체력 향상 및 건강한 습관 형성',
+    focusAreas: ['운동 습관 형성', '칼로리 조절', '규칙적인 식사'],
+    exerciseGoal: '주 5-6회, 하루 30-40분',
+    nutritionGoal: '일일 2,000kcal, 식사 시간 규칙화',
+  },
+  2: {
+    phase: 2,
+    title: 'Phase 2: 강도 증가',
+    weekRange: '5-8주',
+    description: '운동 강도 증가 및 체중 감량 가속화',
+    focusAreas: ['운동 강도 증가', 'HIIT 도입', '단백질 섭취 증가'],
+    exerciseGoal: '주 6회, 하루 40-50분',
+    nutritionGoal: '일일 1,800kcal, 탄수화물 비율 조정',
+  },
+  3: {
+    phase: 3,
+    title: 'Phase 3: 목표 달성',
+    weekRange: '9-12주',
+    description: '목표 달성 및 유지 습관 정착',
+    focusAreas: ['근력 향상', '체지방 감소', '습관 자동화'],
+    exerciseGoal: '주 6회, 하루 45-60분',
+    nutritionGoal: '일일 1,900kcal, 영양 밸런스 최적화',
+  },
+};
+
+/**
+ * 주차별 운동 스케줄 (샘플 - 1주차)
+ */
+const WEEK1_EXERCISE = [
+  {
+    day: '월요일',
+    exercise: '유산소 30분 + 스트레칭 10분',
+    description: '빠르게 걷기, 목표 심박수 100-115회/분',
+  },
+  {
+    day: '화요일',
+    exercise: '근력운동 30분 + 코어 10분',
+    description: '스쿼트, 푸시업, 플랭크, 런지 각 3세트',
+  },
+  {
+    day: '수요일',
+    exercise: '유산소 40분',
+    description: '빠르게 걷기 또는 자전거',
+  },
+  {
+    day: '목요일',
+    exercise: '근력운동 30분 + 코어 10분',
+    description: '전날과 같은 루틴 반복',
+  },
+  {
+    day: '금요일',
+    exercise: '유산소 30분 + 스트레칭 10분',
+    description: '가볍게 조깅 가능',
+  },
+  {
+    day: '토요일',
+    exercise: '근력운동 30분 또는 활동적 레저',
+    description: '등산, 수영 등 즐거운 활동',
+  },
+  {
+    day: '일요일',
+    exercise: '휴식 또는 가벼운 산책 20분',
+    description: '완전 휴식 또는 액티브 리커버리',
+  },
+];
+
+/**
+ * 주차별 식단 가이드 (샘플 - 1주차)
+ */
+const WEEK1_NUTRITION = [
+  {
+    day: '월요일',
+    meals: {
+      breakfast: '현미밥 100g, 된장찌개, 구운 김, 시금치나물, 계란찜',
+      lunch: '귀리밥 100g, 제육볶음(살코기 120g), 배추김치, 미역국',
+      dinner: '현미밥 80g, 고등어구이, 두부샐러드, 깍두기',
+      snacks: ['방울토마토 10개', '무당 그릭 요거트 100g + 블루베리'],
+    },
+  },
+  {
+    day: '화요일',
+    meals: {
+      breakfast: '통밀빵 2장, 아보카도 1/2개, 계란 프라이 1개',
+      lunch: '연어샐러드(연어 150g, 채소, 올리브유), 고구마 1개',
+      dinner: '닭가슴살 샐러드 볼(닭 120g), 현미밥 80g',
+      snacks: ['사과 1/2개 + 아몬드 10알', '당근 스틱 + 후무스'],
+    },
+  },
+  {
+    day: '수요일',
+    meals: {
+      breakfast: '오트밀 50g + 우유, 바나나 1/2개, 호두 5알',
+      lunch: '현미비빔밥(채소 듬뿍, 계란, 참기름 약간)',
+      dinner: '두부스테이크 200g, 브로콜리, 퀴노아 80g',
+      snacks: ['배 1/2개', '두유 200ml'],
+    },
+  },
+  {
+    day: '목요일',
+    meals: {
+      breakfast: '현미밥 100g, 미역국, 계란말이, 깍두기',
+      lunch: '닭가슴살 샌드위치(통밀빵), 샐러드',
+      dinner: '현미밥 80g, 생선조림(동태), 숙주나물',
+      snacks: ['키위 1개', '견과류 믹스 30g'],
+    },
+  },
+  {
+    day: '금요일',
+    meals: {
+      breakfast: '통곡물 시리얼 + 저지방우유, 딸기 5개',
+      lunch: '현미밥 100g, 소고기뭇국(살코기 80g), 나물 3가지',
+      dinner: '해물순두부찌개, 현미밥 80g, 배추김치',
+      snacks: ['셀러리 스틱 + 땅콩버터', '방울토마토 + 모짜렐라'],
+    },
+  },
+  {
+    day: '토요일',
+    meals: {
+      breakfast: '고구마 200g, 삶은 계란 2개, 샐러드',
+      lunch: '닭가슴살 덮밥(현미밥 100g, 채소 볶음)',
+      dinner: '연어구이 150g, 아스파라거스, 퀴노아 80g',
+      snacks: ['오렌지 1개', '프로틴 셰이크'],
+    },
+  },
+  {
+    day: '일요일 (자유 식사 1끼)',
+    meals: {
+      breakfast: '현미죽, 구운 김, 깍두기',
+      lunch: '본인이 원하는 음식 (단, 과식 금지)',
+      dinner: '채소 듬뿍 샤브샤브, 현미밥 80g',
+      snacks: ['과일 샐러드', '견과류'],
+    },
+  },
+];
+
+/**
+ * 전체 12주 프로그램 데이터 생성
+ * (실제로는 12주 전체를 작성하지만, 여기서는 구조만 보여줌)
+ */
+export function getWeeklyProgram(weekNumber: number): WeeklyProgram {
+  const phase: Phase = weekNumber <= 4 ? 1 : weekNumber <= 8 ? 2 : 3;
+  
+  // 각 Phase별로 다른 프로그램 제공 (여기서는 Phase 1 샘플만)
+  return {
+    weekNumber,
+    phase,
+    exerciseSchedule: WEEK1_EXERCISE,
+    nutritionGuide: WEEK1_NUTRITION,
+    weeklyGoals: [
+      `${weekNumber}주차 목표: 운동 ${phase === 1 ? 5 : phase === 2 ? 6 : 6}일 완료`,
+      '식사 시간 규칙화 (아침 7시, 점심 12시, 저녁 6시)',
+      '물 하루 2L 섭취 (8잔)',
+      phase === 1 ? '운동 습관 만들기' : phase === 2 ? '운동 강도 높이기' : '목표 체중 달성',
+    ],
+  };
+}
+
+/**
+ * Phase 번호 계산
+ */
+export function getPhaseFromWeek(weekNumber: number): Phase {
+  if (weekNumber <= 4) return 1;
+  if (weekNumber <= 8) return 2;
+  return 3;
+}
+
+/**
+ * Phase별 색상
+ */
+export const PHASE_COLORS: Record<Phase, string> = {
+  1: '#4CAF50',  // 초록색
+  2: '#FF9800',  // 주황색
+  3: '#2196F3',  // 파란색
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@mui/material-nextjs": "^7.3.2",
         "next": "^15.1.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "recharts": "^3.2.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1488,6 +1489,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1500,6 +1527,18 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1521,6 +1560,69 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1592,6 +1694,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.45.0",
@@ -2663,6 +2771,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -2740,6 +2969,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3024,6 +3259,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3463,6 +3708,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3901,6 +4152,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3940,6 +4201,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5105,6 +5375,29 @@
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -5119,6 +5412,48 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5164,6 +5499,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5733,6 +6074,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6000,6 +6347,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@mui/material-nextjs": "^7.3.2",
     "next": "^15.1.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,67 +1,166 @@
 // 파일 경로: types/index.ts
-// 설명: 애플리케이션 전체에서 사용되는 TypeScript 타입 정의
+// 설명: v2.0 새로운 타입 정의 - 12개 체크 항목 포함
 
 /**
- * 사용자 정보 타입
- * - 로컬 스토리지에 저장되는 사용자 데이터 구조
+ * 사용자 정보 타입 (v2.0 확장)
  */
 export interface User {
-  id: string;                // 고유 식별자 (UUID 형식)
-  email: string;             // 사용자 이메일 (로그인 ID로 사용)
-  password: string;          // 비밀번호 (실제 서비스에서는 해시 처리 필요)
-  startDate: string;         // 12주 프로그램 시작일 (ISO 8601 형식: YYYY-MM-DD)
-  createdAt: string;         // 계정 생성일시
+  id: string;
+  email: string;
+  password: string;
+  startDate: string;              // 프로그램 시작일
+  createdAt: string;
+  
+  // 🆕 v2.0 추가 필드
+  initialWeight: number;          // 초기 체중
+  targetWeight: number;           // 목표 체중
+  initialWaist: number;           // 초기 허리둘레
+  targetWaist: number;            // 목표 허리둘레
 }
 
 /**
- * 일일 체크리스트 타입
- * - 매일의 운동, 식단, 체중 기록을 저장
+ * Phase 타입 (1-4주 / 5-8주 / 9-12주)
+ */
+export type Phase = 1 | 2 | 3;
+
+/**
+ * 일일 체크리스트 v2.0 (12개 항목)
  */
 export interface DailyCheck {
-  date: string;              // 기록 날짜 (YYYY-MM-DD)
-  exerciseCompleted: boolean; // 운동 완료 여부
-  dietCompleted: boolean;    // 식단 준수 여부
-  weight: number | null;     // 체중 기록 (kg, null이면 미기록)
+  date: string;                   // YYYY-MM-DD
+  
+  // 식사 관련 (3개)
+  breakfastCompleted: boolean;    // 아침 식사
+  breakfastTime?: string;         // 식사 시간 (HH:MM)
+  lunchCompleted: boolean;        // 점심 식사
+  lunchTime?: string;
+  dinnerCompleted: boolean;       // 저녁 식사
+  dinnerTime?: string;
+  
+  // 수분 섭취
+  waterIntake: number;            // 물 섭취량 (잔 수, 0-8)
+  
+  // 운동
+  exerciseCompleted: boolean;     // 운동 완료 여부
+  exerciseType?: string;          // 운동 종류 (예: "유산소 30분")
+  exerciseDuration?: number;      // 운동 시간 (분)
+  
+  // 수면
+  sleepHours?: number;            // 수면 시간 (시간 단위)
+  
+  // 신체 측정
+  weight?: number;                // 체중 (kg)
+  waistCircumference?: number;    // 허리둘레 (cm)
+  
+  // 컨디션
+  condition?: number;             // 컨디션 (1-10)
+  memo?: string;                  // 메모
 }
 
 /**
- * 로컬 스토리지 전체 구조 타입
- * - 브라우저 로컬 스토리지에 저장되는 전체 데이터 구조
+ * 주간 통계 v2.0
+ */
+export interface WeeklyStats {
+  weekNumber: number;             // 주차 (1-12)
+  phase: Phase;                   // Phase 번호
+  
+  // 식단 통계
+  mealCompletionRate: number;     // 식사 완료율 (%)
+  waterAverageIntake: number;     // 평균 물 섭취 (잔)
+  
+  // 운동 통계
+  exerciseDays: number;           // 운동 일수
+  totalExerciseMinutes: number;   // 총 운동 시간 (분)
+  
+  // 신체 변화
+  averageWeight?: number;         // 평균 체중
+  averageWaist?: number;          // 평균 허리둘레
+  weightChange?: number;          // 체중 변화 (시작 대비)
+  waistChange?: number;           // 허리둘레 변화
+  
+  // 전체 달성률
+  achievementRate: number;        // 전체 달성률 (%)
+}
+
+/**
+ * Phase별 프로그램 정보
+ */
+export interface PhaseInfo {
+  phase: Phase;
+  title: string;
+  weekRange: string;              // "1-4주"
+  description: string;
+  focusAreas: string[];           // 집중 영역
+  exerciseGoal: string;           // 운동 목표
+  nutritionGoal: string;          // 식단 목표
+}
+
+/**
+ * 주차별 프로그램 상세
+ */
+export interface WeeklyProgram {
+  weekNumber: number;
+  phase: Phase;
+  
+  // 운동 프로그램
+  exerciseSchedule: {
+    day: string;                  // "월요일"
+    exercise: string;             // "유산소 30분 + 스트레칭"
+    description: string;
+  }[];
+  
+  // 식단 가이드
+  nutritionGuide: {
+    day: string;
+    meals: {
+      breakfast: string;
+      lunch: string;
+      dinner: string;
+      snacks?: string[];
+    };
+  }[];
+  
+  // 주간 목표
+  weeklyGoals: string[];
+}
+
+/**
+ * 로컬 스토리지 데이터 구조 v2.0
  */
 export interface LocalStorageData {
-  currentUser: string | null;           // 현재 로그인한 사용자 ID
+  currentUser: string | null;
   users: {
-    [userId: string]: User;             // 모든 사용자 정보 (userId를 키로 사용)
+    [userId: string]: User;
   };
   dailyChecks: {
     [userId: string]: {
-      [date: string]: DailyCheck;       // 사용자별, 날짜별 체크리스트
+      [date: string]: DailyCheck;
     };
   };
 }
 
 /**
- * 주간 통계 타입
- * - 각 주차의 달성률 계산 결과
+ * 달력 날짜 타입 v2.0
  */
-export interface WeeklyStats {
-  weekNumber: number;        // 주차 (1-12)
-  totalDays: number;         // 해당 주의 총 일수
-  completedDays: number;     // 모든 항목을 완료한 날 수
-  partialDays: number;       // 일부 항목만 완료한 날 수
-  achievementRate: number;   // 달성률 (0-100)
+export interface CalendarDay {
+  date: string;
+  dayOfWeek: number;
+  weekNumber: number;
+  phase: Phase;
+  isToday: boolean;
+  isPast: boolean;
+  isFuture: boolean;
+  status: 'excellent' | 'good' | 'partial' | 'incomplete' | 'future';
+  completionRate: number;         // 0-100
 }
 
 /**
- * 달력 날짜 타입
- * - 달력 컴포넌트에서 사용하는 날짜 정보
+ * 차트 데이터 포인트
  */
-export interface CalendarDay {
-  date: string;              // 날짜 (YYYY-MM-DD)
-  dayOfWeek: number;         // 요일 (0: 일요일, 6: 토요일)
-  weekNumber: number;        // 주차 (1-12)
-  isToday: boolean;          // 오늘 날짜 여부
-  isPast: boolean;           // 과거 날짜 여부
-  isFuture: boolean;         // 미래 날짜 여부
-  status: 'completed' | 'partial' | 'incomplete' | 'future'; // 달성 상태
+export interface ChartDataPoint {
+  date: string;                   // "1/1" 형식
+  weight?: number;
+  waist?: number;
+  targetWeight?: number;
+  targetWaist?: number;
 }


### PR DESCRIPTION
## 📌 PR 제목
feat: v2.0 - 12개 항목 체크리스트 및 Phase 시스템 구현

---

## 📖 작업 내용

### 1. 핵심 기능 추가
- **12개 항목 체크리스트 구현**
  - 식사 3회 (아침/점심/저녁) + 시간 기록
  - 물 섭취량 (0-8잔) 슬라이더
  - 운동 완료 여부 + 종류/시간
  - 수면 시간 입력
  - 체중/허리둘레 측정
  - 컨디션 (1-10) 슬라이더
  - 자유 메모
- **Phase 시스템 도입** (12주를 3단계로 구분)
  - Phase 1 (1-4주): 기초 다지기
  - Phase 2 (5-8주): 강도 증가
  - Phase 3 (9-12주): 목표 달성
- **건강 지표 차트 추가** (recharts)
  - 체중/허리둘레 추이 그래프
  - 목표선 표시
  - 토글 방식 전환

### 2. 데이터 구조 개선
- `types/index.ts`: 새로운 타입 정의 (DailyCheck, WeeklyStats 확장)
- `lib/localStorage.ts`: 사용자 초기/목표 체중·허리둘레 저장
- `lib/programData.ts`: 12주 프로그램 데이터 (운동/식단 가이드)

### 3. UI/UX 개선
- **회원가입 2단계 프로세스**
  - Step 1: 계정 정보
  - Step 2: 초기 신체 정보 & 목표 설정
- **달력 시각화 강화**
  - Phase별 색상 구분 (초록/주황/파랑)
  - 완료율 기반 상태 표시 (80%↑: excellent, 50-79%: good 등)
  - 날짜별 완료율 숫자 표시
- **프로그램 가이드 페이지 신규 추가**
  - 주차별 운동 스케줄 테이블
  - 식단 가이드 (7일 메뉴)
  - 주간 목표 리스트

### 4. 컴포넌트 추가/수정
- **신규**: `PhaseIndicator.tsx`, `HealthMetrics.tsx`, `app/program/page.tsx`
- **대폭 수정**: `DailyCheckForm.tsx`, `Calendar.tsx`, `app/page.tsx`
- **부분 수정**: `WeeklyStats.tsx`, `app/signup/page.tsx`, `lib/auth.ts`

---

## ✅ 체크리스트

### 기능 테스트
- [x] 회원가입 시 초기 체중/허리둘레 입력
- [x] 12개 항목 체크리스트 저장/불러오기
- [x] 달력에서 Phase별 색상 구분 표시
- [x] 체중/허리둘레 차트 렌더링 (recharts)
- [x] 프로그램 페이지에서 주차별 운동/식단 확인
- [x] 주차별 통계 계산 (식사율, 물 섭취, 운동 일수)

### 코드 품질
- [x] TypeScript 타입 오류 없음
- [x] ESLint 경고 무시 설정 (초보자 친화)
- [x] 모든 컴포넌트에 한글 주석 추가
- [x] Next.js 15 메타데이터 API 적용 (viewport 분리)

### 문서화
- [x] README.md 작성 (설치 가이드, 사용법)
- [x] 각 파일 상단에 경로/설명 주석
- [x] 복잡한 로직에 단계별 설명 주석

### 의존성
- [x] package.json에 recharts 추가
- [x] 기존 의존성과 호환성 확인

---

## 📝 특이사항

### 추가 패키지 설치 필요
```bash
npm install recharts
```

### 중요 변경사항
1. **LocalStorage 키 변경**: `health-tracker-data` → `health-tracker-v2-data`
   - 기존 v1.0 데이터와 분리
   - 기존 사용자는 재가입 필요 (데이터 마이그레이션 스크립트 미제공)

2. **체크리스트 구조 변경**: 2개 항목 → 12개 항목
   - 기존: exerciseCompleted, dietCompleted, weight
   - 신규: breakfastCompleted, lunchCompleted, dinnerCompleted, waterIntake, exerciseCompleted, exerciseDuration, sleepHours, weight, waistCircumference, condition, memo

3. **Phase별 색상 하드코딩**
   - Phase 1: #4CAF50 (초록)
   - Phase 2: #FF9800 (주황)
   - Phase 3: #2196F3 (파랑)
   - `lib/programData.ts`에서 수정 가능

### 알려진 제한사항
- 프로그램 데이터는 1주차 샘플만 구현 (2-12주차는 1주차 반복)
  - 향후 실제 12주 전체 데이터 추가 필요
- 차트는 측정값이 있는 날짜만 표시 (빈 날짜는 점 없음)
- 로컬스토리지 용량 제한 (~5-10MB)

### 브라우저 호환성
- Chrome/Edge/Safari 최신 버전 권장
- IE11 미지원 (Next.js 15 요구사항)

### 배포 시 주의사항
- GitHub Pages 배포 시 `next.config.ts`의 `REPO_NAME` 변경 필수
- basePath 설정으로 인해 로컬 개발 시 `http://localhost:3000` 사용